### PR TITLE
fixed: set UTF-8 as codec of QTextStream when writing the export file

### DIFF
--- a/Source/Tome/Features/Export/Controller/exportcontroller.cpp
+++ b/Source/Tome/Features/Export/Controller/exportcontroller.cpp
@@ -343,6 +343,7 @@ void ExportController::exportRecords(const RecordExportTemplate& exportTemplate,
 
     // Write record file.
     QTextStream textStream(&device);
+    textStream.setCodec("UTF-8");
     textStream << recordFileString;
 }
 


### PR DESCRIPTION
Otherwise all UTF-8 encoded strings used in record fields are broken in the export file.