### PR TITLE
fixed: crash during map iteration

### DIFF
--- a/Source/Tome/Features/Export/Controller/exportcontroller.cpp
+++ b/Source/Tome/Features/Export/Controller/exportcontroller.cpp
@@ -284,8 +284,8 @@ void ExportController::exportRecords(const RecordExportTemplate& exportTemplate,
 
                         QVariantMap map = fieldValue.toMap();
 
-                        for (QVariantMap::const_iterator it = map.cbegin();
-                             it != map.cend();
+                        for (QVariantMap::const_iterator it = map.begin();
+                             it != map.end();
                              ++it)
                         {
                             QString mapItem = exportTemplate.mapItemTemplate;
@@ -294,7 +294,7 @@ void ExportController::exportRecords(const RecordExportTemplate& exportTemplate,
                             mapItem = mapItem.replace(PlaceholderFieldValue, QVariant(it.value()).toString());
                             fieldValueText.append(mapItem);
 
-                            if (it + 1 != map.end())
+                            if ((it + 1) != map.end())
                             {
                                 fieldValueText.append(exportTemplate.mapItemDelimiter);
                             }


### PR DESCRIPTION
I encountered an access violation during the map iteration. Don't know what exactly caused that issue, but replacing cbegin()/cend() with begin()/end() fixed it. (iterator is still const_iterator)