### PR TITLE
Fix records from being corrupted when a display name is changed

### DIFF
--- a/Source/Tome/Features/Records/Controller/recordscontroller.cpp
+++ b/Source/Tome/Features/Records/Controller/recordscontroller.cpp
@@ -726,6 +726,7 @@ void RecordsController::updateRecord(const QVariant oldId,
         this->removeRecord(oldId);
     }
 
+    // Update record itself.
     Record* record = this->getRecordById(newId);
 
     QVariant recordId = record->id;

--- a/Source/Tome/Features/Records/Controller/recordscontroller.cpp
+++ b/Source/Tome/Features/Records/Controller/recordscontroller.cpp
@@ -726,9 +726,18 @@ void RecordsController::updateRecord(const QVariant oldId,
         this->removeRecord(oldId);
     }
 
-    // Update record itself.
     Record* record = this->getRecordById(newId);
+
+    QVariant recordId = record->id;
+
+    // Update record itself.
     setRecordDisplayName(newId, newDisplayName);
+
+    //When setRecordDisplayName is called it can cause our old pointer to now point to the wrong record due to sorting
+    if(record->id != recordId){
+        record = this->getRecordById(newId);
+    }
+
     setRecordEditorIconFieldId(newId, newEditorIconFieldId);
 
     // Move record, if necessary.


### PR DESCRIPTION
See #195 for more information.