### PR TITLE
Fix reference-type keys not being able to be removed from maps

### DIFF
--- a/Source/Tome/Features/Fields/View/mapwidget.cpp
+++ b/Source/Tome/Features/Fields/View/mapwidget.cpp
@@ -216,8 +216,9 @@ void MapWidget::removeItem()
     int row = selectedIndexes.first().row();
     QTableWidgetItem* keyTableWidgetItem = this->tableWidget->item(row, 0);
 
-    // Update model.
-    this->map.remove(keyTableWidgetItem->text());
+    QVariant actualKey = keyTableWidgetItem->data(Qt::UserRole);
+
+    this->map.remove(actualKey.toString());
 
     // Update view.
     this->tableWidget->removeRow(row);


### PR DESCRIPTION
Fixes issue related to #198 