### PR TITLE
Bug fixes and QoL improvements

### DIFF
--- a/Source/Tome/Core/mainwindow.cpp
+++ b/Source/Tome/Core/mainwindow.cpp
@@ -1832,6 +1832,8 @@ void MainWindow::refreshRecordTable()
         this->recordFieldTableWidget->setEnabled(true);
         this->recordFieldTableWidget->setToolTip(QString());
     }
+
+    recordTreeWidget->updateRecordIcon(id);
 }
 
 void MainWindow::showReadOnlyMessage(const QVariant& recordId)

--- a/Source/Tome/Features/Projects/Model/TomeProject6.xsd
+++ b/Source/Tome/Features/Projects/Model/TomeProject6.xsd
@@ -52,12 +52,13 @@
       <xs:attribute name="IgnoreReadOnly" type="xs:boolean" />
       <xs:attribute name="RecordIdType" use="required">
         <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="String"/>
-            <xs:enumeration value="Integer"/>
-            <xs:enumeration value="Uuid"/>
-          </xs:restriction>
-        </xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="String"/>
+            <xs:enumeration value="Integer"/>
+            <xs:enumeration value="IncrementingInteger"/>
+            <xs:enumeration value="Uuid"/>
+          </xs:restriction>
+        </xs:simpleType>
       </xs:attribute>
     </xs:complexType>
   </xs:element>

--- a/Source/Tome/Features/Projects/Model/recordidtype.h
+++ b/Source/Tome/Features/Projects/Model/recordidtype.h
@@ -12,6 +12,7 @@ namespace Tome
             Invalid,
             String,
             Integer,
+            IncrementingInteger,
             Uuid
         };
 
@@ -30,6 +31,8 @@ namespace Tome
 
                 case RecordIdType::Uuid:
                     return "Uuid";
+                case RecordIdType::IncrementingInteger:
+                    return "IncrementingInteger";
             }
 
             return QString();
@@ -48,6 +51,8 @@ namespace Tome
             else if (recordIdType == "Uuid")
             {
                 return RecordIdType::Uuid;
+            }else if(recordIdType == "IncrementingInteger"){
+                return RecordIdType::IncrementingInteger;
             }
 
             return RecordIdType::Invalid;

--- a/Source/Tome/Features/Projects/View/newprojectwindow.cpp
+++ b/Source/Tome/Features/Projects/View/newprojectwindow.cpp
@@ -24,6 +24,7 @@ NewProjectWindow::NewProjectWindow(QWidget *parent) :
     this->ui->comboBoxRecordIdType->addItem(RecordIdType::toString(RecordIdType::Integer));
     this->ui->comboBoxRecordIdType->addItem(RecordIdType::toString(RecordIdType::Uuid));
     this->ui->comboBoxRecordIdType->addItem(RecordIdType::toString(RecordIdType::String));
+    this->ui->comboBoxRecordIdType->addItem(RecordIdType::toString(RecordIdType::IncrementingInteger));
 
     // Focus project name box.
     ui->lineEditName->setFocus();

--- a/Source/Tome/Features/Records/Controller/recordscontroller.cpp
+++ b/Source/Tome/Features/Records/Controller/recordscontroller.cpp
@@ -552,7 +552,7 @@ void RecordsController::removeRecord(const QVariant& recordId)
     }
 
     // Remove references to record.
-    this->updateRecordReferences(recordId, QString());
+    //this->updateRecordReferences(recordId, QString());
 
     // Remove record.
     for (RecordSetList::iterator itSets = this->model->begin();

--- a/Source/Tome/Features/Records/Controller/recordscontroller.cpp
+++ b/Source/Tome/Features/Records/Controller/recordscontroller.cpp
@@ -54,6 +54,16 @@ const Record RecordsController::addRecord(const QVariant& id,
     // Assign id.
     RecordIdType::RecordIdType recordIdType = this->projectController.getProjectRecordIdType();
 
+    if(recordIdType == RecordIdType::IncrementingInteger && nextRecordId < 0){
+        nextRecordId = 0;
+        foreach(Record record, getRecords()){
+            int recordIntId = record.id.toInt();
+            if(recordIntId > nextRecordId){
+                nextRecordId = recordIntId;
+            }
+        }
+    }
+
     switch (recordIdType)
     {
         case RecordIdType::String:
@@ -64,6 +74,9 @@ const Record RecordsController::addRecord(const QVariant& id,
             break;
         case RecordIdType::Uuid:
             record.id = id.isNull() ? this->generateUuid() : id;
+            break;
+        case RecordIdType::IncrementingInteger:
+            record.id = id.isNull() ? ++nextRecordId : id;
             break;
         case RecordIdType::Invalid:
             const QString errorMessage = "Invalid project record id type.";

--- a/Source/Tome/Features/Records/Controller/recordscontroller.h
+++ b/Source/Tome/Features/Records/Controller/recordscontroller.h
@@ -425,6 +425,8 @@ namespace Tome
             void verifyRecordIntegerIds();
             void verifyRecordStringIds();
             void verifyRecordUuids();
+
+            int nextRecordId = -1;
     };
 }
 

--- a/Source/Tome/Features/Records/View/recordfieldstablewidget.cpp
+++ b/Source/Tome/Features/Records/View/recordfieldstablewidget.cpp
@@ -289,13 +289,15 @@ void RecordFieldsTableWidget::updateFieldValue(int i)
 
         fileName = combinePaths(projectPath, fileName);
 
+        QString fileNameLower = fileName.toLower();
+
         // Get preview.
         QPixmap preview;
 
         QList<QByteArray> supportedImageFormats = QImageReader::supportedImageFormats();
         for (QByteArray& format : supportedImageFormats)
         {
-            if (fileName.endsWith(format))
+            if (fileNameLower.endsWith(format))
             {
                 preview.load(fileName);
 

--- a/Source/Tome/Features/Records/View/recordfieldstablewidget.cpp
+++ b/Source/Tome/Features/Records/View/recordfieldstablewidget.cpp
@@ -253,11 +253,17 @@ void RecordFieldsTableWidget::updateFieldValue(int i)
     if (this->typesController.isTypeOrDerivedFromType(field.fieldType, BuiltInType::Reference))
     {
         QString href;
+        QString valueString = value.toString();
 
-        if (this->recordsController.hasRecord(value))
+        if (!valueString.isEmpty())
         {
-            const Record& record = this->recordsController.getRecord(value);
-            href = QString("<a href='%1'>%2</a>").arg(record.id.toString(), record.displayName);
+            if (this->recordsController.hasRecord(value))
+            {
+                const Record& record = this->recordsController.getRecord(value);
+                href = QString("<a href='%1'>%2</a>").arg(record.id.toString(), record.displayName);
+            }else{
+                href = QString("<i><font color='red'>INVALID REFERENCE</font></i>");
+            }
         }
 
         QModelIndex index = this->model()->index(i, 1);

--- a/Source/Tome/Features/Records/View/recordtreewidget.cpp
+++ b/Source/Tome/Features/Records/View/recordtreewidget.cpp
@@ -219,13 +219,15 @@ void RecordTreeWidget::updateRecordItem(RecordTreeWidgetItem *recordTreeItem)
 
         iconFileName = combinePaths(projectPath, iconFileName);
 
+        QString iconFileNameLower = iconFileName.toLower();
+
         // Get preview.
         QPixmap iconPixmap;
 
         QList<QByteArray> supportedImageFormats = QImageReader::supportedImageFormats();
         for (QByteArray& format : supportedImageFormats)
         {
-            if (iconFileName.endsWith(format))
+            if (iconFileNameLower.endsWith(format))
             {
                 iconPixmap.load(iconFileName);
 

--- a/Source/Tome/Features/Records/View/recordtreewidget.cpp
+++ b/Source/Tome/Features/Records/View/recordtreewidget.cpp
@@ -174,6 +174,13 @@ void RecordTreeWidget::updateRecord(const QVariant& oldId,
     }
 }
 
+void RecordTreeWidget::updateRecordIcon(const QVariant &RecordId)
+{
+    RecordTreeWidgetItem* recordItem = this->getRecordItem(RecordId);
+
+    this->updateRecordItemRecursively(recordItem);
+}
+
 void RecordTreeWidget::updateRecordItem(RecordTreeWidgetItem *recordTreeItem)
 {
     if (recordTreeItem == nullptr)

--- a/Source/Tome/Features/Records/View/recordtreewidget.h
+++ b/Source/Tome/Features/Records/View/recordtreewidget.h
@@ -86,6 +86,12 @@ namespace Tome
                               const QString& newEditorIconFieldId);
 
             /**
+             * @brief Updates the specified records display icon in the hiearchy.
+             * @param RecordId id of the record to update
+             */
+            void updateRecordIcon(const QVariant& RecordId);
+
+            /**
              * @brief Selects the specified record in the hierarchy.
              * @param id Id of the record to select.
              * @param addToHistory Whether to add the record to the navigation history, or not.

--- a/Source/Tome/Features/Records/View/recordwindow.cpp
+++ b/Source/Tome/Features/Records/View/recordwindow.cpp
@@ -138,6 +138,7 @@ void RecordWindow::setRecordIdType(const RecordIdType::RecordIdType recordIdType
     switch (recordIdType)
     {
         case RecordIdType::Integer:
+        case RecordIdType::IncrementingInteger:
         case RecordIdType::Uuid:
         case RecordIdType::Invalid:
             this->ui->labelIdLineEdit->hide();


### PR DESCRIPTION
- Fixed icons not being displayed if their file suffix ends in capitals like PNG (instead of png)
- Fixed icons not being immediately updated in the record tree when the field is changed
- Removing records no longer erases that reference where it was being used. This made it difficult to track down what other records had become broken by a record being erased. Now instead an error is displayed in that records field to make it more clear that it needs to be changed.
- Added a new type of record id called Incrementing Integer. Instead of using random integers for id's, it uses an incremented one. This helps keep record id's small.